### PR TITLE
Update Homebrew installation build from source

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,8 +15,8 @@ jobs:
           ref: "main"
       - name: "Update version"
         run: |
-          wget https://github.com/lunatic-solutions/lunatic/releases/download/v${{ github.event.inputs.version }}/lunatic-macos-universal.tar.gz
-          export SHA256=$(shasum -a 256 lunatic-macos-universal.tar.gz | cut -d ' ' -f 1)
+          wget https://github.com/lunatic-solutions/lunatic/archive/v${{ github.event.inputs.version }}.tar.gz
+          export SHA256=$(shasum -a 256 v0.13.2.tar.gz | cut -d ' ' -f 1)
           sed -i -E 's/[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+/${{ github.event.inputs.version }}/' Formula/lunatic.rb
           sed -i -E 's/sha256 .+/sha256 "'$SHA256'"/' Formula/lunatic.rb
           git config --global user.name "Github Action 'Update lunatic' workflow"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
       - name: "Update version"
         run: |
           wget https://github.com/lunatic-solutions/lunatic/archive/v${{ github.event.inputs.version }}.tar.gz
-          export SHA256=$(shasum -a 256 v0.13.2.tar.gz | cut -d ' ' -f 1)
+          export SHA256=$(shasum -a 256 v${{ github.event.inputs.version }}.tar.gz | cut -d ' ' -f 1)
           sed -i -E 's/[[:digit:]]+\.[[:digit:]]+\.[[:digit:]]+/${{ github.event.inputs.version }}/' Formula/lunatic.rb
           sed -i -E 's/sha256 .+/sha256 "'$SHA256'"/' Formula/lunatic.rb
           git config --global user.name "Github Action 'Update lunatic' workflow"

--- a/Formula/lunatic.rb
+++ b/Formula/lunatic.rb
@@ -1,12 +1,14 @@
 class Lunatic < Formula
   desc "A universal runtime for fast, robust and scalable server-side applications."
   homepage "https://lunatic.solutions"
-  url "https://github.com/lunatic-solutions/lunatic/releases/download/v0.13.2/lunatic-macos-universal.tar.gz"
-  sha256 "b88299a9ba9044c461810d1f1ce3bf98a49b4a5a2f5261ab0b3857cf62a1d310"
+  url "https://github.com/lunatic-solutions/lunatic/archive/v0.13.2.tar.gz"
+  sha256 "0b43d95935be9781ac24f53e095d53fdb34b7dbfe2ff67bb94cad28e4145f869"
   version "0.13.2"
   license any_of: ["MIT", "Apache-2.0"]
 
+  depends_on "rust" => :build
+
   def install
-    bin.install "lunatic"
+    system "cargo", "install", *std_cargo_args
   end
 end


### PR DESCRIPTION
Now Homebrew will install rust on the system and use cargo to install lunatic from source.

I've tested this on my Linux machine using brew locally with the following command.

```
brew install --build-from-source ./Formula/lunatic.rb
```